### PR TITLE
support multiple github workflows per branch

### DIFF
--- a/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/github/common/api/GithubWorkflow.java
+++ b/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/github/common/api/GithubWorkflow.java
@@ -1,0 +1,10 @@
+package io.github.whazzabi.whazzup.business.github.common.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GithubWorkflow {
+
+    public Long id;
+    public String state;
+}

--- a/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/github/common/api/GithubWorkflowRunsResponse.java
+++ b/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/github/common/api/GithubWorkflowRunsResponse.java
@@ -3,9 +3,18 @@ package io.github.whazzabi.whazzup.business.github.common.api;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GithubWorkflowRunsResponse {
 
     public List<GithubWorkflowRun> workflow_runs;
+
+    public Optional<GithubWorkflowRun> findLastRunByWorkflow(GithubWorkflow workflow) {
+        // workflow runs are returned by Github latest first. Let's hope that never changes ;-)
+        return workflow_runs.stream()
+                .filter(run -> Objects.equals(workflow.id, run.workflow_id))
+                .findFirst();
+    }
 }

--- a/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/github/common/api/GithubWorkflowsResponse.java
+++ b/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/github/common/api/GithubWorkflowsResponse.java
@@ -1,0 +1,11 @@
+package io.github.whazzabi.whazzup.business.github.common.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GithubWorkflowsResponse {
+
+    public List<GithubWorkflow> workflows;
+}


### PR DESCRIPTION
First, we check for all active workflows of one repository and then for each workflow we search for the latest run.

This way we make sure that when a workflow is removed or renamed, it will not be included anymore