### PR TITLE
💥 Make cloudwatch team mapper support exclusion patterns

### DIFF
--- a/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/cloudwatch/CloudwatchProperties.java
+++ b/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/cloudwatch/CloudwatchProperties.java
@@ -3,20 +3,19 @@ package io.github.whazzabi.whazzup.business.cloudwatch;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
 import java.util.Map;
 
 @Configuration
 @ConfigurationProperties(prefix = "dash.cloudwatch")
 public class CloudwatchProperties {
 
-    private Map<String, List<String>> alarmToTeamsMapping;
+    private Map<String, MappingPredicates> alarmToTeamsMapping;
 
-    public Map<String, List<String>> getAlarmToTeamsMapping() {
+    public Map<String, MappingPredicates> getAlarmToTeamsMapping() {
         return alarmToTeamsMapping;
     }
 
-    public void setAlarmToTeamsMapping(Map<String, List<String>> alarmToTeamsMapping) {
+    public void setAlarmToTeamsMapping(Map<String, MappingPredicates> alarmToTeamsMapping) {
         this.alarmToTeamsMapping = alarmToTeamsMapping;
     }
 }

--- a/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/cloudwatch/MappingPredicates.java
+++ b/whazzup-core/src/main/java/io/github/whazzabi/whazzup/business/cloudwatch/MappingPredicates.java
@@ -1,0 +1,27 @@
+package io.github.whazzabi.whazzup.business.cloudwatch;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+public class MappingPredicates {
+
+    private List<String> includes;
+    private List<String> excludes;
+
+    public List<String> getIncludes() {
+        return includes != null ? includes : emptyList();
+    }
+
+    public void setIncludes(List<String> includes) {
+        this.includes = includes;
+    }
+
+    public List<String> getExcludes() {
+        return excludes != null ? excludes : emptyList();
+    }
+
+    public void setExcludes(List<String> excludes) {
+        this.excludes = excludes;
+    }
+}


### PR DESCRIPTION
regexes are also now case insensitive.

Using regex negative lookaheads got too cryptic for us to exclude things.

💥  This is a breaking change.

Before the configuration was
```
dash:
  cloudwatch.alarm-to-teams-mapping:
    TeamA:
      - '.*service1.*'
      - '.*service2.*'
```

now its 
```
dash:
  cloudwatch.alarm-to-teams-mapping:
    TeamA:
      includes:
        - '.*service1.*'
        - '.*service2.*'
      excludes:
        - 'foo'
```